### PR TITLE
Implemented updated functional changes for Affiliate program 3.0

### DIFF
--- a/contracts/contracts_BSC/NimbusCore/NimbusReferralProgramLogic.sol
+++ b/contracts/contracts_BSC/NimbusCore/NimbusReferralProgramLogic.sol
@@ -60,11 +60,6 @@ interface INimbusInitialAcquisition {
     function userPurchasesEquivalent(address user) external view returns (uint256);
 }
 
-interface INimbusStakingPool {
-    function balanceOf(address account) external view returns (uint256);
-    function stakingToken() external view returns (IBEP20);
-}
-
 interface INimbusRouter {
     function getAmountsOut(uint amountIn, address[] calldata path) external  view returns (uint[] memory amounts);
 }
@@ -74,7 +69,6 @@ contract NimbusReferralProgramLogic is Ownable {
     INimbusInitialAcquisition public initialAcquisitionContract;
     IBEP20 public immutable NBU;
     INimbusRouter public swapRouter;
-    INimbusStakingPool[] public stakingPools; 
 
     uint[] public levels;
     uint public maxLevel;
@@ -236,23 +230,6 @@ contract NimbusReferralProgramLogic is Ownable {
 
     function updateMinTokenAmountForCheck(uint newMinTokenAmountForCheck) external onlyOwner {
         minTokenAmountForCheck = newMinTokenAmountForCheck;
-    }
-
-    
-
-    function updateStakingPoolAdd(address newStakingPool) external onlyOwner {
-        INimbusStakingPool pool = INimbusStakingPool(newStakingPool);
-        require (pool.stakingToken() == NBU, "Nimbus Referral: Wrong pool staking tokens");
-
-        for (uint i; i < stakingPools.length; i++) {
-            require (address(stakingPools[i]) != newStakingPool, "Nimbus Referral: Pool exists");
-        }
-        stakingPools.push(INimbusStakingPool(pool));
-    }
-
-    function updateStakingPoolRemove(uint poolIndex) external onlyOwner {
-        stakingPools[poolIndex] = stakingPools[stakingPools.length - 1];
-        stakingPools.pop();
     }
     
     function updateSpecialReserveFund(address newSpecialReserveFund) external onlyOwner {

--- a/contracts/contracts_BSC/NimbusCore/NimbusReferralProgramLogic.sol
+++ b/contracts/contracts_BSC/NimbusCore/NimbusReferralProgramLogic.sol
@@ -170,15 +170,11 @@ contract NimbusReferralProgramLogic is Ownable {
         uint sponsorId = users.userSponsor(userId);
         if (sponsorId < 1000000001) return level;
         address sponsorAddress = users.userAddressById(sponsorId);
-        if (isUserBalanceEnough(sponsorAddress)) {
-            uint bonusAmount = amount * levels[level] / 100;
-            TransferHelper.safeTransfer(token, sponsorAddress, bonusAmount);
-            _recordedBalances[token] = _recordedBalances[token] - bonusAmount;
-            emit DistributeFeesForUser(token, sponsorId, bonusAmount);
-            return transferToSponsor(token, sponsorId, amount, ++level, ++levelGuard);
-        } else {
-            return transferToSponsor(token, sponsorId, amount, level, ++levelGuard);
-        }            
+        uint bonusAmount = amount * levels[level] / 100;
+        TransferHelper.safeTransfer(token, sponsorAddress, bonusAmount);
+        _recordedBalances[token] = _recordedBalances[token] - bonusAmount;
+        emit DistributeFeesForUser(token, sponsorId, bonusAmount);
+        return transferToSponsor(token, sponsorId, amount, ++level, ++levelGuard);         
     }
 
     function isUserBalanceEnough(address user) public view returns (bool) {

--- a/contracts/contracts_BSC/NimbusCore/NimbusReferralProgramLogic.sol
+++ b/contracts/contracts_BSC/NimbusCore/NimbusReferralProgramLogic.sol
@@ -123,14 +123,14 @@ contract NimbusReferralProgramLogic is Ownable {
     }
 
     function distributeEarnedFees(address token, uint userId) external {
-        distributeFees(token, userId);
+        if (_undistributedFees[token][userId] > 0) distributeFees(token, userId);
         uint callerId = users.userIdByAddress(msg.sender);
         if (_undistributedFees[token][callerId] > 0) distributeFees(token, callerId);
     }
 
     function distributeEarnedFees(address token, uint[] memory userIds) external {
         for (uint i; i < userIds.length; i++) {
-            distributeFees(token, userIds[i]);
+            if (_undistributedFees[token][userIds[i]] > 0) distributeFees(token, userIds[i]);
         }
         
         uint callerId = users.userIdByAddress(msg.sender);
@@ -140,7 +140,7 @@ contract NimbusReferralProgramLogic is Ownable {
     function distributeEarnedFees(address[] memory tokens, uint userId) external {
         uint callerId = users.userIdByAddress(msg.sender);
         for (uint i; i < tokens.length; i++) {
-            distributeFees(tokens[i], userId);
+            if (_undistributedFees[tokens[i]][userId] > 0) distributeFees(tokens[i], userId);
             if (_undistributedFees[tokens[i]][callerId] > 0) distributeFees(tokens[i], callerId);
         }
     }


### PR DESCRIPTION
1. Changed `isUserBalanceEnough` function to take `userPurchases` data from **NimbusInitialAcquisition** contract. By requirements, dashboard shouldn't be locked anymore when user invested minimal amount. Previously, it depended on current NBU balance and staked balance for user. Also, staking pools not used anymore in this contract.
2. Removed check for enough balance from `transferToSponsor` function because by new requirements it shouldn't skip users which don't have enough balance.
3. Added check for `undistributedFees` of user IDs passed in `distributeEarnedFees` function. Previously, if one of user ID passed in this function have 0 undistributedFees, transaction was reverted. That's not optimal, because on front-end side when passed whole referral tree, users need to be checked one by one for undistributed fees and exclude it from call. After this change, contract will check this and just exclude users with 0 undistributedFees allowing to continue execution for other user IDs.